### PR TITLE
Remove link to blog from Navbar

### DIFF
--- a/src/core/Navbar.js
+++ b/src/core/Navbar.js
@@ -23,12 +23,6 @@ const Navbar = props => {
           tnesland.me
         </Link>
         <Link
-          className="link lightgrey dim ph2 ttl"
-          to="/blog"
-        >
-          Blog
-        </Link>
-        <Link
           className="link lightgrey dim pl2 ttl"
           target="_blank"
           to="/resume"


### PR DESCRIPTION
Temporarily remove `/blog` from Navbar. Until I have more content this blog page looks kind of silly. We can leave the page in-place, but I think it's best to remove the link until I have enough content to justify the link.