### PR TITLE
Make authorship type explicit on resume

### DIFF
--- a/src/pages/printable-resume.js
+++ b/src/pages/printable-resume.js
@@ -119,7 +119,9 @@ const PrintableResume = props => (
         </span>
       </article>
       <article>
-        <h3 className="mb0 bb b--black-10">Publications</h3>
+        <h3 className="mb0 bb b--black-10">
+          Publications (as contributing author)
+        </h3>
         {map(
           props => (
             <Publication baseFontSize="12px" key={props.name} {...props} />

--- a/src/pages/resume.js
+++ b/src/pages/resume.js
@@ -114,7 +114,9 @@ const Resume = props => (
         )}
       </article>
       <article className="mv4">
-        <h3 className="bb b--black-10">Publications</h3>
+        <h3 className="bb b--black-10">
+          Publications (as contributing author)
+        </h3>
         {map(
           props => <Publication key={props.name} {...props} />,
           resumeData.publications


### PR DESCRIPTION
Many readers of resume might assume that I am insinuating that I am first-author
on these publications, which I am not. So let's make that clear.